### PR TITLE
PHPのコンテナが無いと言われたので、パッチバージョン指定をやめる

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/php:7.2.1-apache-node-browsers
+      - image: circleci/php:7.2-apache-node-browsers
       - image: circleci/mysql:5.7
       
       # Specify service dependencies here if necessary


### PR DESCRIPTION
### エラー内容
```
image cache not found on this host, downloading circleci/php:7.2.1-apache-node-browsers
```