### PR TITLE
CORSでクレデンシャルを許可する

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -12,7 +12,7 @@ return [
     |
     */
    
-    'supportsCredentials' => false,
+    'supportsCredentials' => true,
     'allowedOrigins' => ['*'],
     'allowedOriginsPatterns' => [],
     'allowedHeaders' => ['*'],


### PR DESCRIPTION
* [CORSリクエストでクレデンシャル\(≒クッキー\)を必要とする場合の注意点 \- Qiita](https://qiita.com/kawaz/items/1e51c374b7a13c21b7e2)