### PR TITLE
Redisによるキャッシュを使用するのをやめる

### DIFF
--- a/app/Http/Controllers/Api/V1/ArticleController.php
+++ b/app/Http/Controllers/Api/V1/ArticleController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use App\DataAccess\Eloquent\Article;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
 
 
 class ArticleController extends Controller

--- a/config/cache.php
+++ b/config/cache.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('CACHE_DRIVER', 'redis'),
+    'default' => env('CACHE_DRIVER', 'file'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Heroku Redisは数ヶ月に一回ホスト名が変わってしまう。現状APIのキャッシュはしていないが、内部的に使用する設定になっている。500になるたびに調査・変更するのは時間の無駄なので、設定から外す。