### PR TITLE
アクセストークン発行エンドポイントのテストケースを追加

### DIFF
--- a/tests/Feature/Api/OAuthTokenTest.php
+++ b/tests/Feature/Api/OAuthTokenTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Laravel\Passport\Passport;
+use Laravel\Passport\ClientRepository;
+use App\DataAccess\Eloquent\User;
+use Tests\TestCase;
+
+class OAuthTokenTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private $client;
+    private $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $clientRepository = new ClientRepository();
+        $this->client = $clientRepository->createPasswordGrantClient(null, 'Password Grant', url('/'));
+
+        $this->user = factory(User::class)->create();
+    }
+
+    public function testOAuthToken_アクセストークン発行が成功する()
+    {
+        $params = [
+            'grant_type' => 'password',
+            'client_id' => $this->client->id,
+            'client_secret' => $this->client->secret,
+            'username' => $this->user->email,
+            'password' => 'secret',
+        ];
+        $response = $this->postJson('/oauth/token', $params);
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'token_type',
+                'expires_in',
+                'access_token',
+                'refresh_token',
+            ]);
+    }
+
+}

--- a/tests/Feature/Api/OAuthTokenTest.php
+++ b/tests/Feature/Api/OAuthTokenTest.php
@@ -34,6 +34,7 @@ class OAuthTokenTest extends TestCase
             'username' => $this->user->email,
             'password' => 'secret',
         ];
+        // MEMO: アクセストークンを発行する際にoauth-(public|private).keyを使用するので、CircleCIでテストをする際は、環境変数にPASSPORT_PUBLIC_KEY、PASSPORT_PRIVATE_KEYを設定すること
         $response = $this->postJson('/oauth/token', $params);
         $response->assertStatus(200)
             ->assertJsonStructure([


### PR DESCRIPTION
## 困っていること
Laravelのバージョンアップにあたり、Passportの挙動が変わらないか不安だった

## 解決すること
テストケースを追加することでアクセストークンが正常に発行されるか担保する

## 参考にした
* [Laravel PassportでWeb APIの認証を実装する【初期設定編】 \| 大阪のシステム開発なら 株式会社ウィズテクノロジー](https://www.whizz-tech.co.jp/1442/)