### PR TITLE
laravel-corsをv.1.0.3にアップグレードしたらCORS問題が発生したので修正

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -11,7 +11,8 @@ return [
     | to accept any value.
     |
     */
-   
+
+    'paths' => [],
     'supports_credentials' => true,
     'allowed_origins' => ['*'],
     'allowed_origins_patterns' => [],


### PR DESCRIPTION
v1.0.0から `paths` オプションが追加された。恐らくこれが未設定なのが原因と思われる。
refs: https://github.com/fruitcake/laravel-cors/releases/tag/v1.0.0