### PR TITLE
Fix laravel-cors warning for Warning: Ambiguous class resolution

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,7 +19,6 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
-        \Fruitcake\Cors\HandleCors::class,
     ];
 
     /**


### PR DESCRIPTION
### Error
```sh
Warning: Ambiguous class resolution, "Fruitcake\Cors\HandleCors" was found in both "/var/www/collective-times/api/vendor/barryvdh/laravel-cors/src/HandleCors.php" and "/var/www/collective-times/api/vendor/fruitcake/laravel-cors/src/HandleCors.php", the first will be used.
Warning: Ambiguous class resolution, "Fruitcake\Cors\CorsServiceProvider" was found in both "/var/www/collective-times/api/vendor/barryvdh/laravel-cors/src/CorsServiceProvider.php" and "/var/www/collective-times/api/vendor/fruitcake/laravel-cors/src/CorsServiceProvider.php", the first will be used.
```

It didn't have to load in Kernel.php because of auto discovering.