### PR TITLE
Revert "Fix laravel-cors warning for Warning: Ambiguous class resolution"

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
+        \Fruitcake\Cors\HandleCors::class,
     ];
 
     /**


### PR DESCRIPTION
Reverts collective-times/api#279

```sh
Access to XMLHttpRequest at 'https://collective-times-api.herokuapp.com/v1/articles' from origin 'https://collective-times-front.netlify.com' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```
が再発してしまったのでこの修正は必要だった