### PR TITLE
画像URLが出来ない時にエラーになる問題を修正する

### DIFF
--- a/app/ContentsParser/Entity/RSS2.php
+++ b/app/ContentsParser/Entity/RSS2.php
@@ -38,7 +38,11 @@ class RSS2 implements EntityInterface
     public function getImageUrl()
     {
         try {
-            $imageUrl = $this->createCrawler($this->item->get_content())->filter('body img')->eq(0)->attr('src');
+            $content = $this->item->get_content();
+            if (is_null($content)) {
+                return;
+            }
+            $imageUrl = $this->createCrawler($content)->filter('body img')->eq(0)->attr('src');
             $parsedUrl = parse_url($imageUrl);
             if ($this->isImageUrl($parsedUrl['path'])) {
                 return $imageUrl;


### PR DESCRIPTION
```
Argument 1 passed to Symfony\Component\DomCrawler\Crawler::parseXhtml() must be of the type string, null given, called in /app/vendor/symfony/dom-crawler/Crawler.php on line 192
```