### PR TITLE
Description に登録する文字列が長すぎる問題を回避する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .env
+.phpunit.result.cache

--- a/app/Console/Commands/Crawl.php
+++ b/app/Console/Commands/Crawl.php
@@ -59,7 +59,7 @@ class Crawl extends Command
                 Article::create([
                     'site_id' => $site->id,
                     'title' => $entity->getTitle(),
-                    'description' => $entity->getDescription(),
+                    'description' => mb_substr($entity->getDescription(), 0, 1000),
                     'publish_date' => $entity->getPublishDate(),
                     'article_url' => $entity->getArticleUrl(),
                     'source_url' => $site->source_url,


### PR DESCRIPTION

```
SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'description' at row 1 
```