### PR TITLE
DBをMySQLからPostgreSQLに移行する

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -10,7 +10,7 @@ DB_CONNECTION=pgsql
 DB_HOST=database
 DB_PORT=5432
 DB_DATABASE=collective_times_development
-DB_USERNAME=collective_times
+DB_USERNAME=collective_times_development
 DB_PASSWORD=collective_times_development
 
 BROADCAST_DRIVER=log

--- a/.env.development
+++ b/.env.development
@@ -6,9 +6,9 @@ APP_URL=http://localhost
 
 LOG_CHANNEL=stack
 
-DB_CONNECTION=mysql
+DB_CONNECTION=pgsql
 DB_HOST=database
-DB_PORT=3306
+DB_PORT=5432
 DB_DATABASE=collective_times_development
 DB_USERNAME=collective_times
 DB_PASSWORD=collective_times_development

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ npm-debug.log
 yarn-error.log
 .env
 .phpunit.result.cache
+/docker/db

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ $ docker-compose exec api php artisan migrate
 ```sh
 $ docker-compose exec api vendor/bin/phpunit
 ```
+
+## 困ったときは
+
+1. `storage/logs/laravel.log` でアプリケーションログを確認すること

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     environment:
       TZ: 'Asia/Tokyo'
       POSTGRES_USER: 'collective_times_development'
-      POSTGRES_PASSWORD: 'collective_times'
+      POSTGRES_PASSWORD: 'collective_times_development'
       POSTGRES_DB: 'collective_times_development'
   cache:
     image: redis:4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,15 +17,17 @@ services:
     depends_on:
       - database
   database:
-    image: mysql:5.7
+    image: postgres:12
     volumes:
-      - ./docker/database/my.cnf:/etc/mysql/conf.d/my.cnf:ro
+      - ./docker/db/data:/var/lib/postgresql/data
+      - ./docker/db/sql:/docker-entrypoint-initdb.d
+    ports:
+      - 5432:5432
     environment:
-      TZ: Asia/Tokyo
-      MYSQL_DATABASE: collective_times_development
-      MYSQL_USER: collective_times
-      MYSQL_PASSWORD: collective_times_development
-      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      TZ: 'Asia/Tokyo'
+      POSTGRES_USER: 'collective_times_development'
+      POSTGRES_PASSWORD: 'collective_times'
+      POSTGRES_DB: 'collective_times_development'
   cache:
     image: redis:4
 

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -qq update \
 RUN pecl install redis-4.0.1 \
     && docker-php-ext-enable redis
 
-RUN docker-php-ext-install mbstring pdo pdo_pgsql
+RUN docker-php-ext-install mbstring pdo pdo_pgsql pgsql
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 WORKDIR /var/www/collective-times/api
 

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,12 +1,13 @@
 FROM php:7.4-fpm
 
+# NOTE: libpq-devは pdo_pgsqlのインストールに必要
 RUN apt-get -qq update \
-      && apt-get -qq install -y --no-install-recommends unzip zlib1g-dev git libonig-dev
+      && apt-get -qq install -y --no-install-recommends unzip zlib1g-dev git libonig-dev libpq-dev
 
 RUN pecl install redis-4.0.1 \
     && docker-php-ext-enable redis
 
-RUN docker-php-ext-install mbstring pdo_mysql
+RUN docker-php-ext-install mbstring pdo pdo_pgsql
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 WORKDIR /var/www/collective-times/api
 


### PR DESCRIPTION
### なぜ移行する？
- Herokuで利用している Clear DB MySQLのPunchプラン($9.99/mo)で容量1GBだが、PostgreSQLなら無料プランで同じ容量。コスト削減のためPostgreSQLに移行したい。
  - https://elements.heroku.com/addons/cleardb
  - https://elements.heroku.com/addons/heroku-postgresql 

### 参考にした
- [docker\-composeでNginx \+ Laravel5\.8\(PHP7\.3\) \+ PostgreSQLの環境を作る \- Qiita](https://qiita.com/nagi125/items/775e7ebda4718f61a330)
- [Docker/Postgresでpassword authentication failedが出た場合の対処法 \- Qiita](https://qiita.com/piggydev/items/c61f830f94c86b937fb2)